### PR TITLE
Updated the System.Linq.Dynamic.core package

### DIFF
--- a/samplebrowser/syncfusion.samplebrowser.wpf_60.csproj
+++ b/samplebrowser/syncfusion.samplebrowser.wpf_60.csproj
@@ -3626,7 +3626,7 @@
     </Reference>
     <PackageReference Include="MdXaml" Version="1.27.0" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.17.1" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.4" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
   </ItemGroup>

--- a/samplebrowser/syncfusion.samplebrowser.wpf_80.csproj
+++ b/samplebrowser/syncfusion.samplebrowser.wpf_80.csproj
@@ -3626,7 +3626,7 @@
     </Reference>
     <PackageReference Include="MdXaml" Version="1.27.0" />
     <PackageReference Include="Microsoft.SemanticKernel" Version="1.17.1" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.4.4" />
+    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.0.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.19" />
   </ItemGroup>


### PR DESCRIPTION
## Description: 

Need to resolve the Vulnerability issue in file format WPF-demos.

## Solution:

We faced a vulnerability issue with the package (System.Linq.Dynamic.Core), so to resolve this, I upgraded the version of the System.Linq.Dynamic.Core package. After the upgrade, I verified that the fileformat WPF demos are working fine in both the core and framework versions.